### PR TITLE
std::nth_element version of percentile

### DIFF
--- a/inc/WireCellUtil/Waveform.h
+++ b/inc/WireCellUtil/Waveform.h
@@ -194,13 +194,13 @@ namespace WireCell {
 	
 	// Return the median value.  This is rather slow as it
 	// involves a sort.
-	real_t median(realseq_t wave);
+	real_t median(realseq_t& wave);
 
 	// Return the median value.  This is faster but introduces
 	// inaccuracies due to binning.
 	real_t median_binned(realseq_t& wave);
 
-	real_t percentile(realseq_t wave, real_t percentage);
+	real_t percentile(realseq_t& wave, real_t percentage);
 	real_t percentile_binned(realseq_t& wave, real_t percentage);
 
 	/// Discrete Fourier transform of real sequence.  Returns full

--- a/src/Waveform.cxx
+++ b/src/Waveform.cxx
@@ -73,7 +73,7 @@ Waveform::realseq_t WireCell::Waveform::phase(const Waveform::compseq_t& seq)
 }
 
 
-Waveform::real_t WireCell::Waveform::median(Waveform::realseq_t wave)
+Waveform::real_t WireCell::Waveform::median(Waveform::realseq_t& wave)
 {
     return percentile(wave,0.5);
 }
@@ -84,7 +84,7 @@ Waveform::real_t WireCell::Waveform::median_binned(Waveform::realseq_t& wave)
 }
 
 
-Waveform::real_t WireCell::Waveform::percentile(Waveform::realseq_t wave, real_t percentage)
+Waveform::real_t WireCell::Waveform::percentile(Waveform::realseq_t& wave, real_t percentage)
 {
     std::nth_element(wave.begin(), wave.begin()+wave.size()*percentage, wave.end());
     return wave.at(wave.size()*percentage);

--- a/src/Waveform.cxx
+++ b/src/Waveform.cxx
@@ -75,9 +75,7 @@ Waveform::realseq_t WireCell::Waveform::phase(const Waveform::compseq_t& seq)
 
 Waveform::real_t WireCell::Waveform::median(Waveform::realseq_t wave)
 {
-    std::sort(wave.begin(), wave.end());
-    return wave[wave.size()/2];
-    //return percentile(wave,0.5);
+    return percentile(wave,0.5);
 }
 
 Waveform::real_t WireCell::Waveform::median_binned(Waveform::realseq_t& wave)
@@ -88,8 +86,8 @@ Waveform::real_t WireCell::Waveform::median_binned(Waveform::realseq_t& wave)
 
 Waveform::real_t WireCell::Waveform::percentile(Waveform::realseq_t wave, real_t percentage)
 {
-    std::sort(wave.begin(), wave.end());
-    return wave[wave.size() * percentage];
+    std::nth_element(wave.begin(), wave.begin()+wave.size()*percentage, wave.end());
+    return wave.at(wave.size()*percentage);
 }
 
 Waveform::real_t WireCell::Waveform::percentile_binned(Waveform::realseq_t& wave, real_t percentage){


### PR DESCRIPTION
Use `std::nth_element` in the `Waveform::percentile` function.

Profiled using [img/test/test-pdsp-6apas-bee.sh](https://github.com/WireCell/wire-cell-img/blob/master/test/test-pdsp-6apas-bee.sh) with data from [sio/test/test_beedeposource.zip](https://github.com/WireCell/wire-cell-sio/blob/master/test/test_beedeposource.zip)
**used apa0 only in this profiling**

Thanks @brettviren and @goowenq in the test setup.

In this profiling test, comparing with the histogram method in the `Waveform::percentile_binned` the `std::nth_element` in the `Waveform::percentile` is about 4 times faster. Resulting ~25% speed up of the `SigProc::OmnibusSigProc`

![image](https://user-images.githubusercontent.com/10383186/62671919-aeaeba00-b966-11e9-87ed-4ea0a4d0accb.png)

In principle the `nth_element` should be more precise than the hist method for there is no smearing from binning.
I compared the medians generated from these two methods. The differences roughly follow a Gaussian distribution with ~0.25 as sigma. Compared with the one sigma ADC value range, this difference is very small.
![image](https://user-images.githubusercontent.com/10383186/62672354-58db1180-b968-11e9-8b74-8a03ea95e04d.png)

